### PR TITLE
Add test artifact upload to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,18 @@ jobs:
 
       - name: Run tests
         working-directory: duet-rpc
-        run: cabal test
+        shell: bash
+        run: |
+          set -euo pipefail
+          cabal test --test-option=--hide-successes | tee test-results.log
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results
+          path: duet-rpc/test-results.log
+          retention-days: 7
 
       - name: Run HLint
         run: hlint duet-rpc


### PR DESCRIPTION
Implements Phase 3 test artifact capture:
- Captures test output to test-results.log with focused verbosity
- Uploads artifacts with 7-day retention
- Uses if: always() to upload even on test failure